### PR TITLE
enable to compile densecrf

### DIFF
--- a/include/densecrf/examples/dense_inference.cpp
+++ b/include/densecrf/examples/dense_inference.cpp
@@ -34,11 +34,11 @@
 const float GT_PROB = 0.5;
 
 // Simple classifier that is 50% certain that the annotation is correct
-MatrixXf computeUnary( const VectorXs & lbl, int M ){
+Eigen::MatrixXf computeUnary( const VectorXs & lbl, int M ){
 	const float u_energy = -log( 1.0 / M );
 	const float n_energy = -log( (1.0 - GT_PROB) / (M-1) );
 	const float p_energy = -log( GT_PROB );
-	MatrixXf r( M, lbl.rows() );
+  Eigen::MatrixXf r( M, lbl.rows() );
 	r.fill(u_energy);
 	//printf("%d %d %d \n",im[0],im[1],im[2]);
 	for( int k=0; k<lbl.rows(); k++ ){
@@ -76,7 +76,7 @@ int main( int argc, char* argv[]){
 	}
 	
 	/////////// Put your own unary classifier here! ///////////
-	MatrixXf unary = computeUnary( getLabeling( anno, W*H, M ), M );
+  Eigen::MatrixXf unary = computeUnary( getLabeling( anno, W*H, M ), M );
 	///////////////////////////////////////////////////////////
 	
 	// Setup the CRF model
@@ -97,7 +97,7 @@ int main( int argc, char* argv[]){
 	crf.addPairwiseBilateral( 80, 80, 13, 13, 13, im, new PottsCompatibility( 10 ) );
 	
 	// Do map inference
-// 	MatrixXf Q = crf.startInference(), t1, t2;
+// 	Eigen::MatrixXf Q = crf.startInference(), t1, t2;
 // 	printf("kl = %f\n", crf.klDivergence(Q) );
 // 	for( int it=0; it<5; it++ ) {
 // 		crf.stepInference( Q, t1, t2 );

--- a/include/densecrf/examples/dense_learning.cpp
+++ b/include/densecrf/examples/dense_learning.cpp
@@ -113,7 +113,7 @@ int main( int argc, char* argv[]){
 	
 	// Get the logistic features (unary term)
 	// Here we just use the color as a feature
-	MatrixXf logistic_feature( 4, N ), logistic_transform( M, 4 );
+  Eigen::MatrixXf logistic_feature( 4, N ), logistic_transform( M, 4 );
 	logistic_feature.fill( 1.f );
 	for( int i=0; i<N; i++ )
 		for( int k=0; k<3; k++ )
@@ -131,7 +131,7 @@ int main( int argc, char* argv[]){
 	// Add simple pairwise potts terms
 	crf.addPairwiseGaussian( 3, 3, new PottsCompatibility( 1 ) );
 	// Add a longer range label compatibility term
-	crf.addPairwiseBilateral( 80, 80, 13, 13, 13, im, new MatrixCompatibility( MatrixXf::Identity(M,M) ) );
+  crf.addPairwiseBilateral( 80.0f, 80.0f, 13.0f, 13.0f, 13.0f, &*im, new MatrixCompatibility::MatrixCompatibility( Eigen::MatrixXf::Identity(M,M) ) );
 	
 	// Choose your loss function
 // 	LogLikelihood objective( labeling, 0.01 ); // Log likelihood loss
@@ -143,7 +143,7 @@ int main( int argc, char* argv[]){
 	int NIT = 5;
 	const bool verbose = true;
 	
-	MatrixXf learning_params( 3, 3 );
+  Eigen::MatrixXf learning_params( 3, 3 );
 	// Optimize the CRF in 3 phases:
 	//  * First unary only
 	//  * Unary and pairwise

--- a/include/densecrf/examples/test_optimization.cpp
+++ b/include/densecrf/examples/test_optimization.cpp
@@ -31,10 +31,10 @@
 
 class ExampleEnergy: public EnergyFunction {
 public:
-	virtual VectorXf initialValue() {
-		return VectorXf::Zero( 2 );
+	virtual Eigen::VectorXf initialValue() {
+		return Eigen::VectorXf::Zero( 2 );
 	}
-	virtual double gradient( const VectorXf & x, VectorXf & dx ) {
+	virtual double gradient( const Eigen::VectorXf & x, Eigen::VectorXf & dx ) {
 		double fx = (x[0] - 1)*(x[0] - 6) + (x[0] - 4)*(x[1] - 2)*(x[0] - 4)*(x[1] - 2) + x[1]*x[1];
 		dx[0] = 2*x[0] - 7 + 2*(x[1] - 2)*(x[0] - 4)*(x[1] - 2);
 		dx[1] = 2*x[1] + 2*(x[0] - 4)*(x[1] - 2)*(x[0] - 4);
@@ -45,9 +45,9 @@ public:
 
 int main() {
 	ExampleEnergy e;
-	VectorXf m = minimizeLBFGS( e, true );
+  Eigen::VectorXf m = minimizeLBFGS( e, true );
 	
-	VectorXf g( m.rows() );
+  Eigen::VectorXf g( m.rows() );
 	std::cout<<"Minimized "<<e.gradient(m,g)<<std::endl;
 	std::cout<<g<<std::endl;
 

--- a/include/densecrf/examples/test_pairwise.cpp
+++ b/include/densecrf/examples/test_pairwise.cpp
@@ -33,20 +33,20 @@
 class PairwiseEnergy: public EnergyFunction {
 protected:
 	PairwisePotential p_;
-	MatrixXf v0_, v1_;
+	Eigen::MatrixXf v0_, v1_;
 public:
-	PairwiseEnergy( const MatrixXf & f, const MatrixXf & v0, const MatrixXf & v1 ):p_( f, new PottsCompatibility(), DIAG_KERNEL, NORMALIZE_SYMMETRIC ),v0_(v0),v1_(v1) {
+	PairwiseEnergy( const Eigen::MatrixXf & f, const Eigen::MatrixXf & v0, const Eigen::MatrixXf & v1 ):p_( f, new PottsCompatibility(), DIAG_KERNEL, NORMALIZE_SYMMETRIC ),v0_(v0),v1_(v1) {
 	}
-	virtual VectorXf initialValue() {
+	virtual Eigen::VectorXf initialValue() {
 		return p_.kernelParameters();
 	}
-	virtual void setInitialValue( const VectorXf & v ) {
+	virtual void setInitialValue( const Eigen::VectorXf & v ) {
 		p_.setKernelParameters( v );
 	}
-	virtual double gradient( const VectorXf & x, VectorXf & dx ) {//NORMALIZE_SYMMETRIC
+	virtual double gradient( const Eigen::VectorXf & x, Eigen::VectorXf & dx ) {//NORMALIZE_SYMMETRIC
 		p_.setKernelParameters( x );
 		dx = p_.kernelGradient( v0_, v1_ );
-		MatrixXf tmp = 0*v1_;
+		Eigen::MatrixXf tmp = 0*v1_;
 		p_.apply( tmp, v1_ );
 		return (tmp.array()*v0_.array()).sum();
 	}
@@ -54,13 +54,13 @@ public:
 
 int main() {
 	int N = 1000, M = 4, d = 2;
-	MatrixXf f = 0.3*MatrixXf::Random( d, N );
-	MatrixXf a = MatrixXf::Random( M, N ), b = MatrixXf::Random( M, N );
+	Eigen::MatrixXf f = 0.3*Eigen::MatrixXf::Random( d, N );
+	Eigen::MatrixXf a = Eigen::MatrixXf::Random( M, N ), b = Eigen::MatrixXf::Random( M, N );
 	PairwiseEnergy e( f.array(), a, a );
 	
-	VectorXf p = e.initialValue();
-// 	p = VectorXf::Random( p.rows() );
-	VectorXf g = p;
+	Eigen::VectorXf p = e.initialValue();
+// 	p = Eigen::VectorXf::Random( p.rows() );
+	Eigen::VectorXf g = p;
 	std::cout<<"start = "<<e.gradient( p, g )<<std::endl;
 // 	std::cout<<p.transpose()<<std::endl;
 	p = minimizeLBFGS( e, 5, 1 );
@@ -69,7 +69,7 @@ int main() {
 	std::cout<<"ng = "<<numericGradient( e, p ).transpose()<<std::endl;
 	std::cout<<"ng = "<<numericGradient( e, p, 1e-2 ).transpose()<<std::endl;
 // 	int id;
-// 	VectorXf dg = g.transpose()-numericGradient( e, p );
+// 	Eigen::VectorXf dg = g.transpose()-numericGradient( e, p );
 // 	dg.array().abs().maxCoeff( &id );
 // 	std::cout<<computeFunction( e, p-g, 0.02*g ).transpose()<<std::endl;
 }

--- a/include/densecrf/examples/test_permutohedral.cpp
+++ b/include/densecrf/examples/test_permutohedral.cpp
@@ -33,27 +33,27 @@
 class PermutohedralEnergy: public EnergyFunction {
 protected:
 	Permutohedral p;
-	MatrixXf f_, v0_, v1_;
+	Eigen::MatrixXf f_, v0_, v1_;
 public:
-	PermutohedralEnergy( const MatrixXf & f, const MatrixXf & v0, const MatrixXf & v1 ):f_(f),v0_(v0), v1_(v1) {
+	PermutohedralEnergy( const Eigen::MatrixXf & f, const Eigen::MatrixXf & v0, const Eigen::MatrixXf & v1 ):f_(f),v0_(v0), v1_(v1) {
 		p.init( f );
 	}
-	virtual VectorXf initialValue() {
-		MatrixXf f = f_;
+	virtual Eigen::VectorXf initialValue() {
+		Eigen::MatrixXf f = f_;
 		f.resize( f_.cols()*f_.rows(), 1 );
 		return f;
 	}
-	virtual void setInitialValue( const VectorXf & v ) {
-		MatrixXf f = v;
+	virtual void setInitialValue( const Eigen::VectorXf & v ) {
+		Eigen::MatrixXf f = v;
 		f.resize( f_.rows(), f_.cols() );
 		f_ = f;
 	}
-	virtual double gradient( const VectorXf & x, VectorXf & dx ) {
-		MatrixXf f = x;
+	virtual double gradient( const Eigen::VectorXf & x, Eigen::VectorXf & dx ) {
+		Eigen::MatrixXf f = x;
 		f.resizeLike( f_ );
 		p.init( f );
 		
-		MatrixXf bv = p.compute( v1_, true );
+		Eigen::MatrixXf bv = p.compute( v1_, true );
 		dx = 0*x;
 		p.gradient( dx.data(), v0_.data(), v1_.data(), v0_.rows() );
 		
@@ -63,9 +63,9 @@ public:
 
 int main() {
 	int N = 1000, M = 4, d = 4;
-	MatrixXf f = 0.3*MatrixXf::Random( d, N );
-	MatrixXf a = MatrixXf::Random( M, N ), b = MatrixXf::Random( M, N );
-	MatrixXf p;
+	Eigen::MatrixXf f = 0.3*Eigen::MatrixXf::Random( d, N );
+	Eigen::MatrixXf a = Eigen::MatrixXf::Random( M, N ), b = Eigen::MatrixXf::Random( M, N );
+	Eigen::MatrixXf p;
 	PermutohedralEnergy e( f.array(), a, b );
 	if( !p.cols() || !p.rows() )
 		p = e.initialValue();
@@ -73,7 +73,7 @@ int main() {
 		p.array() += 0.1;
 		e.setInitialValue( p );
 	}
-	VectorXf g = p;
+	Eigen::VectorXf g = p;
 	std::cout<<"start = "<<e.gradient( p, g )<<std::endl;
 	std::cout<<p.transpose()<<std::endl;
 	p = minimizeLBFGS( e, 5, 0 );
@@ -82,7 +82,7 @@ int main() {
 	std::cout<<"ng = "<<numericGradient( e, p ).transpose()<<std::endl;
 	std::cout<<"ng = "<<numericGradient( e, p, 1e-2 ).transpose()<<std::endl<<std::endl;
 	int id;
-	VectorXf dg = g-numericGradient( e, p );
+	Eigen::VectorXf dg = g-numericGradient( e, p );
 	dg.array().abs().maxCoeff( &id );
 	std::cout<<computeFunction( e, p-g, 0.02*g ).transpose()<<std::endl;
 }

--- a/include/densecrf/external/CMakeLists.txt
+++ b/include/densecrf/external/CMakeLists.txt
@@ -1,2 +1,2 @@
 include_directories( liblbfgs/include )
-add_library( lbfgs liblbfgs/lib/lbfgs.c )
+add_library( lbfgs liblbfgs/lib/lbfgs.cpp )


### PR DESCRIPTION
DenseCRF was not compileable. Particularly, in include/densecrf/external/CMakeLists.txt was wrongly specified extension for lbfgs. Example source codes lacked of specified namespace for Eigen library.
